### PR TITLE
 Fix check_metadata() to generate heptafluorobutyric columns

### DIFF
--- a/scripts/R_ci/helper_functions.R
+++ b/scripts/R_ci/helper_functions.R
@@ -264,6 +264,18 @@ check_metadata <- function(x) {
     x <- add_column(x, eluent.A.pH = 0)
   }
 
+  if(!"eluent.A.heptafluorobutyric" %in% colnames(x)) {
+    x <- add_column(x, eluent.A.heptafluorobutyric = 0)
+  }
+
+  if(!"eluent.A.heptafluorobutyric.unit" %in% colnames(x)) {
+    x <- add_column(x, eluent.A.heptafluorobutyric.unit = NA_character_)
+  } else {
+    if(all(x$eluent.A.heptafluorobutyric.unit %in% c(0, NA))) {
+      x <- x %>% mutate(eluent.A.heptafluorobutyric.unit = NA_character_)
+    }
+  }
+
 
   # eluent B -------------------------------------------------------------------
   # base solvents
@@ -487,6 +499,18 @@ check_metadata <- function(x) {
   # pH value
   if(!"eluent.B.pH" %in% colnames(x)) {
     x <- add_column(x, eluent.B.pH = 0)
+  }
+
+  if(!"eluent.B.heptafluorobutyric" %in% colnames(x)) {
+    x <- add_column(x, eluent.B.heptafluorobutyric = 0)
+  }
+
+  if(!"eluent.B.heptafluorobutyric.unit" %in% colnames(x)) {
+    x <- add_column(x, eluent.B.heptafluorobutyric.unit = NA_character_)
+  } else {
+    if(all(x$eluent.B.heptafluorobutyric.unit %in% c(0, NA))) {
+      x <- x %>% mutate(eluent.B.heptafluorobutyric.unit = NA_character_)
+    }
   }
 
   # eluent C -------------------------------------------------------------------
@@ -713,6 +737,18 @@ check_metadata <- function(x) {
     x <- add_column(x, eluent.C.pH = 0)
   }
 
+  if(!"eluent.C.heptafluorobutyric" %in% colnames(x)) {
+    x <- add_column(x, eluent.C.heptafluorobutyric = 0)
+  }
+
+  if(!"eluent.C.heptafluorobutyric.unit" %in% colnames(x)) {
+    x <- add_column(x, eluent.C.heptafluorobutyric.unit = NA_character_)
+  } else {
+    if(all(x$eluent.C.heptafluorobutyric.unit %in% c(0, NA))) {
+      x <- x %>% mutate(eluent.C.heptafluorobutyric.unit = NA_character_)
+    }
+  }
+
   # eluent D -------------------------------------------------------------------
   # base solvents
   if(!"eluent.D.h2o" %in% colnames(x)) {
@@ -937,6 +973,18 @@ check_metadata <- function(x) {
     x <- add_column(x, eluent.D.pH = 0)
   }
 
+  if(!"eluent.D.heptafluorobutyric" %in% colnames(x)) {
+    x <- add_column(x, eluent.D.heptafluorobutyric = 0)
+  }
+
+  if(!"eluent.D.heptafluorobutyric.unit" %in% colnames(x)) {
+    x <- add_column(x, eluent.D.heptafluorobutyric.unit = NA_character_)
+  } else {
+    if(all(x$eluent.D.heptafluorobutyric.unit %in% c(0, NA))) {
+      x <- x %>% mutate(eluent.D.heptafluorobutyric.unit = NA_character_)
+    }
+  }
+
   # gradient conditions --------------------------------------------------------
   if(!"gradient.start.A" %in% colnames(x)) {
     x <- add_column(x, gradient.start.A = 0)
@@ -1019,6 +1067,8 @@ check_metadata <- function(x) {
                "eluent.A.medronic",
                "eluent.A.medronic.unit",
                "eluent.A.pH",
+               "eluent.A.heptafluorobutyric",
+               "eluent.A.heptafluorobutyric.unit",
                "eluent.B.h2o",
                "eluent.B.meoh",
                "eluent.B.acn",
@@ -1059,6 +1109,8 @@ check_metadata <- function(x) {
                "eluent.B.medronic",
                "eluent.B.medronic.unit",
                "eluent.B.pH",
+               "eluent.B.heptafluorobutyric",
+               "eluent.B.heptafluorobutyric.unit",
                "eluent.C.h2o",
                "eluent.C.meoh",
                "eluent.C.acn",
@@ -1099,6 +1151,8 @@ check_metadata <- function(x) {
                "eluent.C.medronic",
                "eluent.C.medronic.unit",
                "eluent.C.pH",
+               "eluent.C.heptafluorobutyric",
+               "eluent.C.heptafluorobutyric.unit",
                "eluent.D.h2o",
                "eluent.D.meoh",
                "eluent.D.acn",
@@ -1139,6 +1193,8 @@ check_metadata <- function(x) {
                "eluent.D.medronic",
                "eluent.D.medronic.unit",
                "eluent.D.pH",
+               "eluent.D.heptafluorobutyric",
+               "eluent.D.heptafluorobutyric.unit",
                "gradient.start.A",
                "gradient.start.B",
                "gradient.start.C",


### PR DESCRIPTION
The canonical schema (example/0259_metadata.tsv + all processed_data/*) was upgraded to 185 columns including eluent.{A,B,C,D}.heptafluorobutyric(.unit) in commits 56f6cefcb and 0b80b88, but check_metadata() in helper_functions.R was never updated to emit them. As a result, re-running metadata_standardize.R on any dataset whose raw data lacks HFBA (e.g. 0002) produces only 177 columns, and order_metadata_tsv.py then fails its column-set assertion against the 185-column 0259 template.

This PR adds the 8 missing columns following the existing medronic block pattern (value defaults to 0, .unit defaults to NA_character_), placed immediately after each eluent.X.pH to match the canonical order. Datasets that already carry HFBA columns are unaffected.